### PR TITLE
Fix index error when a new service (or one that doesn't have yesterday's cost)

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -28,7 +28,7 @@ def sparkline(datapoints):
     return line
 
 def delta(costs):
-    if (costs[-1] >= 1 and costs[-2] >= 1):
+    if (len(costs) > 1 and costs[-1] >= 1 and costs[-2] >= 1):
         # This only handles positive numbers
         result = ((costs[-1]/costs[-2])-1)*100.0
     else:


### PR DESCRIPTION
Before:

```json
{
    "errorMessage": "list index out of range",
    "errorType": "IndexError",
    "stackTrace": [
        "  File \"/var/task/handler.py\", line 101, in report_cost\n    buffer += f\"{service_name:{longest_name_len}} ${costs[-1]:8,.2f} {delta(costs):4.0f}% {sparkline(costs):7}\\n\"\n",
        "  File \"/var/task/handler.py\", line 31, in delta\n    if (costs[-1] >= 1 and costs[-2] >= 1):\n"
    ]
}
```

After:

```
null
```