### PR TITLE
fix lookback period

### DIFF
--- a/handler.py
+++ b/handler.py
@@ -6,8 +6,9 @@ import requests
 import sys
 
 n_days = 7
-yesterday = datetime.datetime.today() - datetime.timedelta(days=1)
-week_ago = yesterday - datetime.timedelta(days=n_days)
+today = datetime.datetime.today()
+yesterday = today - datetime.timedelta(days=1)
+week_ago = today - datetime.timedelta(days=n_days)
 
 # It seems that the sparkline symbols don't line up (probably based on font?) so put them last
 # Also, leaving out the full block because Slack doesn't like it: '█'
@@ -62,11 +63,11 @@ def lambda_handler(event, context):
 def report_cost(group_by: str = "SERVICE", length: int = 5, cost_aggregation: str = "UnblendedCost", result: dict = None, yesterday: str = None, new_method=True):
 
     if yesterday is None:
-        yesterday = datetime.datetime.today() - datetime.timedelta(days=1)
+        yesterday = today - datetime.timedelta(days=1)
     else:
         yesterday = datetime.datetime.strptime(yesterday, '%Y-%m-%d')
 
-    week_ago = yesterday - datetime.timedelta(days=n_days)
+    week_ago = today - datetime.timedelta(days=n_days)
     # Generate list of dates, so that even if our data is sparse,
     # we have the correct length lists of costs (len is n_days)
     list_of_dates = [
@@ -94,7 +95,7 @@ def report_cost(group_by: str = "SERVICE", length: int = 5, cost_aggregation: st
     query = {
         "TimePeriod": {
             "Start": week_ago.strftime('%Y-%m-%d'),
-            "End": yesterday.strftime('%Y-%m-%d'),
+            "End": today.strftime('%Y-%m-%d'),
         },
         "Granularity": "DAILY",
         "Filter": {


### PR DESCRIPTION
When testing this I noticed the lookback period actually skips "yesterday". For instance, today is 7/10/2023, the 7 day period queried is from 7/2/2023 to 7/8/2023 (inclusive). When Slack prints out the message, `Yesterday` is actually referring 7/8/2023, instead of 7/9/2023.

I'm not sure if this is intentional, but it won't work for my use case, so I made some modifications to look back properly. If today is 7/10/2023, the query should be from 7/3/2023 to 7/9/2023 (inclusive), and `Yesterday` should refer to 7/9/2023 in the Slack message. 