### PR TITLE
pipenv set to version 2023.7.4 in install

### DIFF
--- a/.github/workflows/serverless-packaging.yml
+++ b/.github/workflows/serverless-packaging.yml
@@ -2,42 +2,41 @@ name: Build and Test Serverless Packaging
 
 on:
   push:
-    branches: [ "master" ]
+    branches: ["master"]
   pull_request:
-    branches: [ "master" ]
+    branches: ["master"]
 
 permissions:
   contents: read
 
 jobs:
   build:
-
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v3
-    - name: Set up Python 3.10
-      uses: actions/setup-python@v3
-      with:
-        python-version: "3.10"
-    - uses: actions/setup-node@v3
-      with:
-        node-version: 16
-        cache: 'npm'
-    - name: Install dependencies
-      run: |
-        python -m pip install --upgrade pip
-        pip install flake8 pipenv
-    - name: Lint with flake8
-      run: |
-        # stop the build if there are Python syntax errors or undefined names
-        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
-        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
-        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
-    - name: Test Serverless packaging
-      run: |
-        npm -g install serverless
-        serverless create --template-path . --path="/tmp/app-aws-cost" --name="app-aws-cost"
-        cd /tmp/app-aws-cost
-        serverless plugin install -n serverless-python-requirements
-        serverless package --stage="prod" --param="slack_url=https://hooks.slack.com/services/xxx/yyy/zzzz"
+      - uses: actions/checkout@v3
+      - name: Set up Python 3.10
+        uses: actions/setup-python@v3
+        with:
+          python-version: "3.10"
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+          cache: "npm"
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install flake8 pipenv==2023.7.4
+      - name: Lint with flake8
+        run: |
+          # stop the build if there are Python syntax errors or undefined names
+          flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+          # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+          flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+      - name: Test Serverless packaging
+        run: |
+          npm -g install serverless
+          serverless create --template-path . --path="/tmp/app-aws-cost" --name="app-aws-cost"
+          cd /tmp/app-aws-cost
+          serverless plugin install -n serverless-python-requirements
+          serverless package --stage="prod" --param="slack_url=https://hooks.slack.com/services/xxx/yyy/zzzz"

--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ Sends daily breakdowns of AWS costs to a Slack channel.
 1. Install pipenv
 
     ```
-    pip install pipenv
+    pip install pipenv==2023.7.4
     ```
 
 1. Install serverless python requirements


### PR DESCRIPTION
Stack deploy gives an error with pipenv versions released after 2023.7.4

```
Error:
Error: `pipenv lock --keep-outdated` Exited with code 1
```

The reason is pipenv 2023.7.9 marks [deprecation](https://github.com/pypa/pipenv/blob/30067b458bd7a429f242736b7fde40c9bd4d4f14/CHANGELOG.rst#pipenv-202379-2023-07-09) of `pipenv lock --keep-outdated` which is used by [serverless-python-requirements](https://github.com/serverless/serverless-python-requirements/) 

A quick fix is to set the pipenv version in the installation instruction until [serverless-python-requirements](https://github.com/serverless/serverless-python-requirements/) release that handles the latest pipenv version.
